### PR TITLE
Add PixelFontInputs

### DIFF
--- a/RDTweaks/RDTweaks.cs
+++ b/RDTweaks/RDTweaks.cs
@@ -237,7 +237,7 @@ namespace RDTweaks
                 if (textComponent.font != appropriateFont)
                 {
                     textComponent.font = appropriateFont;
-                    textComponent.fontSize = 8;
+                    textComponent.fontSize = 7;
                 }
             }
             
@@ -247,10 +247,13 @@ namespace RDTweaks
             public static bool Prefix(InputField ___urlInput, int ___lastUrlInputTextLength)
             {
                 if (!PConfig.pixelFontInputs.Value) return true;
-                
+
                 if (___lastUrlInputTextLength != ___urlInput.text.Length)
+                {
                     RDEditorUtils.UpdateUIText(___urlInput.textComponent, ___urlInput.text);
-                
+                    ___urlInput.textComponent.fontSize = 7;
+                }
+
                 return true;
             }
         }

--- a/RDTweaks/RDTweaks.csproj
+++ b/RDTweaks/RDTweaks.csproj
@@ -265,6 +265,9 @@
       <HintPath>..\packages\UnityEngine.Modules.2021.2.8\lib\net45\UnityEngine.UaaLAnalyticsModule.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="UnityEngine.UI">
+      <HintPath>..\Libs\UnityEngine.UI.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine.UIElementsModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\packages\UnityEngine.Modules.2021.2.8\lib\net45\UnityEngine.UIElementsModule.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
Implements the suggestion from https://discord.com/channels/296802696243970049/298308153190121472/978218888489730048 and changes the fonts of the CLS input fields to the pixel font (if set in the options).
 
**Note: A publicized version of UnityEngine.UI.dll is now required to build the plugin.**